### PR TITLE
Various fixes for glib 2.56

### DIFF
--- a/examples/echo/main.c
+++ b/examples/echo/main.c
@@ -23,6 +23,16 @@
 #include <glib-unix.h>
 #include "ygg.h"
 
+#if !GLIB_CHECK_VERSION(2, 58, 0)
+#  define G_SOURCE_FUNC(f) ((GSourceFunc) (void (*)(void)) (f))
+
+static gchar *
+g_date_time_format_iso8601 (GDateTime *datetime)
+{
+  return g_date_time_format (datetime, "%C%y-%m-%dT%H:%M:%S.%fZ");
+}
+#endif
+
 static void
 foreach (const gchar *key,
               const gchar *value,

--- a/src/meson.build
+++ b/src/meson.build
@@ -87,6 +87,9 @@ libygg_gir = gnome.generate_gir(libygg,
 )
 
 test_deps = libygg_deps
+test_args = [
+  '--tap',
+]
 
 test('test-ygg-metadata',
   executable('test-ygg-metadata',
@@ -99,6 +102,7 @@ test('test-ygg-metadata',
     'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
   ],
   protocol: 'tap',
+  args: test_args,
 )
 
 test('test-ygg-worker',
@@ -112,4 +116,5 @@ test('test-ygg-worker',
     'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
   ],
   protocol: 'tap',
+  args: test_args,
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -42,7 +42,6 @@ libygg_deps = [
 
 add_project_arguments(
   '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56',
-  '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_68',
   language: 'c'
 )
 

--- a/src/test-ygg-metadata.c
+++ b/src/test-ygg-metadata.c
@@ -59,8 +59,8 @@ _foreach (const gchar *key,
           const gchar *val,
           gpointer     user_data)
 {
-  GString *output = (GString *) user_data;
-  g_string_append_printf (output, "'%s' = '%s'\n", key, val);
+  GList *keys = (GList *) user_data;
+  (void) ! g_list_append (keys, g_strdup_printf ("'%s' = '%s'", key, val));
 }
 
 static void
@@ -70,9 +70,11 @@ test_ygg_metadata_foreach (void)
   g_autoptr (GVariant) variant = g_variant_new_parsed ("{'key': 'val', 'a': 'b'}");
   g_autoptr (YggMetadata) metadata = ygg_metadata_new_from_variant (variant, &err);
   g_assert_null (err);
-  g_autoptr (GString) output = g_string_new (NULL);
-  ygg_metadata_foreach (metadata, _foreach, output);
-  g_assert_cmpstr (output->str, ==, "'key' = 'val'\n'a' = 'b'\n");
+  GList *keys = g_list_alloc ();
+  ygg_metadata_foreach (metadata, _foreach, keys);
+  g_assert_nonnull (g_list_find_custom (keys, "'key' = 'val'", (GCompareFunc) g_strcmp0));
+  g_assert_nonnull (g_list_find_custom (keys, "'a' = 'b'", (GCompareFunc) g_strcmp0));
+  g_list_free_full (keys, g_free);
 }
 
 int

--- a/src/test-ygg-worker.c
+++ b/src/test-ygg-worker.c
@@ -21,6 +21,7 @@
 
 #include <glib.h>
 #include <locale.h>
+#include <stdlib.h>
 
 #include "ygg.h"
 
@@ -53,7 +54,11 @@ fixture_setup (TestFixture   *fixture,
   /* Add the private directory with our in-tree service files.
    */
   relative = g_test_build_filename (G_TEST_BUILT, "services", NULL);
+#if GLIB_CHECK_VERSION(2, 58, 0)
   servicesdir = g_canonicalize_filename (relative, NULL);
+#else
+  servicesdir = realpath (relative, NULL);
+#endif
   g_test_dbus_add_service_dir (fixture->dbus, servicesdir);
 
   /* Start the private D-Bus daemon
@@ -99,7 +104,11 @@ main (int   argc,
       char *argv[])
 {
   setlocale (LC_ALL, "");
-  g_test_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
+  g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+               G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+               NULL);
 
   g_test_add ("/ygg/worker/connect",
               TestFixture,

--- a/src/ygg-worker.c
+++ b/src/ygg-worker.c
@@ -55,7 +55,7 @@ message_new (YggWorker   *worker,
              YggMetadata *metadata,
              GBytes      *data)
 {
-  Message *message = g_rc_box_new0 (Message);
+  Message *message = (Message *) g_new0 (Message, 1);
 
   message->worker = g_object_ref (worker);
   message->addr = g_strdup (addr);
@@ -135,7 +135,7 @@ message_free (Message *message)
   g_free (message->response_to);
   g_object_unref (message->metadata);
   g_bytes_unref (message->data);
-  g_rc_box_release (message);
+  g_free (message);
 }
 
 G_DEFINE_QUARK (ygg-worker-error-quark, ygg_worker_error)


### PR DESCRIPTION
Tweak the way glib is used so it can build and work also with glib 2.56, which is the current required version (as available in EL 8).

This means:
- provide fallback implementations of, or simply avoid using, features available in newer versions
- fix one test to not rely on internal glib workings (i.e. hash order)
- force TAP for tests

See the messages of the individual commits for more detailed descriptions.