### PR TITLE
build: downgrade meson requirement

### DIFF
--- a/dist/srpm/libygg.spec.in
+++ b/dist/srpm/libygg.spec.in
@@ -31,7 +31,7 @@ URL:            %{forgeurl}
 Source:         %{forgesource}
 
 BuildRequires:  gcc
-BuildRequires:  meson
+BuildRequires:  meson >= 0.58.2
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(gio-2.0) >= 2.56.0
 BuildRequires:  pkgconfig(gobject-introspection-1.0)

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libygg', 'c',
           version: '0.1.0',
-    meson_version: '>= 0.59.0',
+    meson_version: '>= 0.58.2',
   default_options: [ 'warning_level=2', 'werror=false', 'c_std=gnu11', ],
 )
 


### PR DESCRIPTION
Downgrade the required version of meson to 0.58.2, which is what EL 8 distributions ship.

It seems there is no behaviour change.