### PR TITLE
feat(py): Python stub file for Ygg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+python/build/
+python/src/*.egg-info/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ It is also possible to compile _libygg_ into an RPM suitable for installation on
 Fedora-based distributions. See the README in [dist/srpm](./dist/srpm) for
 details.
 
+### Python stubs
+
+_libygg_ can be used in Python as a `gi.repository` module (see the `examples/` directory).
+
+You can install the type stubs into your virtual environment:
+
+```bash
+python3 -m pip install PyGObject-stubs
+python3 -m pip install ./python
+# Or, without cloning this repository:
+python3 -m pip install git+https://github.com/RedHatInsights/libygg.git@main#subdirectory=python
+```
+
 ## Features
 
 * Worker Developer API

--- a/examples/echo-py/README.md
+++ b/examples/echo-py/README.md
@@ -1,4 +1,14 @@
+# Echo Python worker
+
 _echo-py_ is an example "echo" yggdrasil worker, written in Python, that uses
 _libygg_ through gobject-introspection to communicate with `yggd` over D-Bus.
 `main.py` is documented with comments demonstrating how to create and connect a
 worker using the API.
+
+## Setting up
+
+```shell
+$ sudo dnf install python3-gobject
+$ python3 -m venv --system-site-packages .venv && source .venv/bin/activate
+$ DBUS_STARTER_BUS_TYPE=session python3 main.py
+```

--- a/examples/echo-py/main.py
+++ b/examples/echo-py/main.py
@@ -3,6 +3,7 @@ import argparse
 import datetime
 import logging
 import uuid
+from typing import Any, Optional
 
 import gi
 
@@ -16,7 +17,7 @@ except ImportError or ValueError as e:
     logging.error("cannot import {}".format(e))
 
 
-def transmit_done(worker, result):
+def transmit_done(worker: Ygg.Worker, result):
     """
     A callback that is invoked once when the `transmit` method call
     finishes.
@@ -32,10 +33,22 @@ def transmit_done(worker, result):
         worker.set_feature("UpdatedAt", datetime.datetime.now().isoformat())
 
 
-def handle_rx(worker, addr, id, response_to, meta_data, data):
-    """
-    A callback that is invoked each time the worker receives data from the
-    dispatcher.
+def handle_rx(
+    worker: Ygg.Worker,
+    addr: str,
+    id: "Ygg.UUID",
+    response_to: Optional["Ygg.UUID"],
+    meta_data: Optional[dict[str, Any]],
+    data: Any,
+):
+    """Function invoked each time data are received from the dispatcher.
+
+    :param worker: An instance of `Ygg.Worker`.
+    :param addr: Destination of the data to be transmitted.
+    :param id: A UUID.
+    :param response_to: A UUID the data is the response to.
+    :param meta_data: A set of key/value pairs.
+    :param data: The data.
     """
     logging.debug("handle_rx")
     logging.debug("addr = {}".format(addr))
@@ -52,8 +65,9 @@ def handle_rx(worker, addr, id, response_to, meta_data, data):
     worker.transmit(addr, str(uuid.uuid4()), id, meta_data, data, None, transmit_done)
 
 
-def handle_event(event):
-    """
+def handle_event(event: Ygg.WorkerEvent):
+    """Function called on an event signal.
+
     A callback that is invoked each time the worker receives an event signal
     from the dispatcher.
     """
@@ -72,7 +86,7 @@ if __name__ == "__main__":
     # Set the log level parsed from flags
     logging.basicConfig(level=args.log_level)
 
-    # Create a worker with the directive value 'echo_py'.
+    # Create a worker with the directive value 'echo'
     worker = Ygg.Worker(directive=args.directive, remote_content=False, features=None)
 
     # Set a data receive handler function

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,1 @@
+Python stub file providing type hints for the Ygg GI object.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "PyGObject-Ygg-stubs"
+authors = [
+    {name = "CSI Client Tools", email = "csi-client-tools-bugs@redhat.com" },
+]
+description = "Stub files for Ygg GObject"
+requires-python = ">=3.6"
+version = "0.1.0"
+dependencies = [
+    "PyGObject-stubs",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"*" = ["*.pyi"]

--- a/python/src/gi-stubs/repository/Ygg.pyi
+++ b/python/src/gi-stubs/repository/Ygg.pyi
@@ -1,0 +1,157 @@
+from enum import IntEnum
+from typing import Any, Callable, Optional, TypeAlias
+
+from gi.repository import GLib, GObject
+
+YGG_DISPATCHER_EVENT_RECEIVED_DISCONNECT: int = 1
+YGG_DISPATCHER_EVENT_UNEXPECTED_DISCONNECT: int = 2
+YGG_DISPATCHER_EVENT_CONNECTION_RESTORED: int = 3
+
+UUID: TypeAlias = str
+
+RxFunc: TypeAlias = Callable[["Worker", str, UUID, Optional[UUID], Optional[dict[str, Any]], Any], None]
+EventFunc: TypeAlias = Callable[["WorkerEvent", Any], None]
+
+
+class YggMetadata:
+    """Key-value store."""
+
+    def get(self, key: str) -> Optional[str]:
+        """Look up a value in the store."""
+    
+    def set(self, key: str, value: str) -> bool:
+        """Insert a value into the store.
+        
+        :returns: `True` if the key did not exist, `False` otherwise.
+        """
+
+
+class WorkerEvent(IntEnum):
+    """Worker signals.
+    
+    Signals emitted by Worker instances to indicate the operating state of
+    the worker to interested parties.
+    """
+    BEGIN: int = 1
+    """Worker has accepted the data and is beggining to process it."""
+    END: int = 2
+    """Worker has completed processing on the last received data."""
+    WORKING: int = 3
+    """Worker is processing the data."""
+
+
+class Worker(GObject.GPointer):
+    def __init__(self, directive: str, remote_content: bool, features: Optional[dict[str, Any]]) -> None:
+        """Create new worker.
+
+        :param directive:
+            The worker directive name.
+            This is used to create the D-Bus interface path when joined with
+            prefix `com.redhat.Yggdrasil1.Worker1.`.
+        :param remote_content:
+            The worker requires content from a remote URL.
+        :param features:
+            An initial table of values to use as the worker's feature map.
+        :raises gi.repository.GLib.GError:
+            `directive` is not valid directive;
+            `features` is not `None` or a valid dictionary.
+        """
+
+    def connect(self) -> bool:
+        """Connects to the D-Bus bus.
+
+        The worker connects to either a system or session D-Bus connection.
+        
+        It then exports itself onto the bus, implementing the
+        `com.redhat.Yggdrasil1.Worker1` interface.
+
+        :returns: `True` if the connection was successful.
+        :raises gi.repository.GLib.GError: The connection was not successful.
+        """
+
+    def transmit(
+        self,
+        addr: str,
+        id: UUID,
+        response_to: Optional[UUID],
+        metadata: Optional[dict[str, Any]],
+        data: bytes,
+        cancellable: GLib.Cancellable,
+        callback: GLib.GAsyncReadyCallback,
+    ) -> None:
+        """Transmits the data.
+
+        Invokes the `com.redhat.Yggdrasil1.Dispatcher1.Transmit` D-Bus method
+        asynchronously. To receive the response from the D-Bus method, call
+        `transmit_finish`.
+
+        :param addr: Destination address of the data to be transmitted.
+        :param id: A UUID.
+        :param response_to: A UUID the data is in response to.
+        :param metadata: Key/value pairs associated with the data.
+        :param data: The data.
+        :param cancellable:
+        :param callback:
+            A callback function to be invoked when the task is complete.
+        """
+
+    def transmit_finish(
+        self,
+        res: GLib.GAsyncResult,
+        response_code: int,
+        response_metadata: YggMetadata,
+        response_data: GLib.Bytes,
+    ) -> bool:
+        """Finishes transmitting the data.
+
+        :param res: The result.
+        :param response_code: An integer status code.
+        :param response_metadata: A map of key/value pairs.
+        :param response_data: Data received in response to the transmit.
+        :returns: `True` on success, `False` on error.
+        """
+
+    def emit_event(self, event: WorkerEvent, message_id: str, message: Optional[str]) -> bool:
+        """Emit a `com.redhat.Yggdrasil1.Worker`.Event` signal.
+        
+        :param event: The event to emit.
+        :param message_id: The message ID.
+        :param message: The message to include with the emitted signal.
+        :returns: `True` on success, `False` on error.
+        """
+
+    def get_feature(self, key: str) -> str:
+        """Looks up a value in the features table.
+
+        :param key: The key to look up in the features table.
+        :raises gi.repository.GLib.GError: Key is not present.
+        """
+
+    def set_feature(self, key: str, value: str) -> bool:
+        """Stores the value.
+
+        Emits a signal on the worker's D-Bus path and interface
+        `org.freedesktop.DBus.Properties` as `PropertiesChanged`.
+        
+        :returns: `True` if the key did not exist.
+        """
+
+    def set_rx_func(
+        self,
+        func: RxFunc,
+    ) -> bool:
+        """Sets a callable that is invoked when data is received.
+
+        :param func: The callback function.
+        :returns: `True` when the callable is saved.
+        """
+
+    def set_event_func(
+        self,
+        func: EventFunc,
+    ) -> bool:
+        """Sets a callable that is invoked when an event is received.
+        
+        :param func: The callback function.
+        :returns: `True` if setting the function handler succeeded.
+        """


### PR DESCRIPTION
This patch adds a .pyi stub for libygg/`gi.repository.Ygg`.

* Card ID: CCT-187

---

To be answered before merging:

- [ ] **How to keep version of `libygg` and the bindings in sync?**
  I think they don't need to be. By keeping them separate, it may be clear that the bindings may be out of date if the versions don't match.
- [ ] **UUID is a type alias.**
  As of now, the UUID is an alias defined in the `.pyi` file, and it is present to get stronger type control (since UUIDs have a specific well-known format). If this was defined on the C level and not Python level, the type hints could be `uuid: Ygg.UUID` instead of `uuid: "Ygg.UUID"`.
- [ ] **Are the docstrings OK?**
  Are they descriptive and correct so a developer not familiar with the C code can use them to write a worker?