### PR TITLE
fix: initialize variables in test

### DIFF
--- a/src/test-ygg-worker.c
+++ b/src/test-ygg-worker.c
@@ -45,7 +45,7 @@ static void
 fixture_setup (TestFixture   *fixture,
                gconstpointer  user_data)
 {
-  g_autofree gchar *relative, *servicesdir;
+  g_autofree gchar *relative = NULL, *servicesdir = NULL;
 
   /* Create the global dbus-daemon for this test suite
    */


### PR DESCRIPTION
These two variables are `g_autofree`, which means that `g_free()` will be automatically called when their scope ends; if the execution ends before they are initialized, then the `free()` (called by `g_free()`) will be called on undefined pointers, leading to issues.

The simple fix here is to initialize them at declaration to ensure nothing wrong happens, no matter the flow.