### PR TITLE
chore(test): drop RHEL/CentOS 8 support

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,7 +30,6 @@ jobs:
     additional_repos:
       - "copr://@yggdrasil/latest"
     targets:
-      - centos-stream-8
       - centos-stream-9
       - fedora-all
       - rhel-8
@@ -42,7 +41,6 @@ jobs:
     owner: "@yggdrasil"
     project: latest
     targets:
-      - centos-stream-8
       - centos-stream-9
       - fedora-all
       - rhel-8

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,7 +32,6 @@ jobs:
     targets:
       - centos-stream-9
       - fedora-all
-      - rhel-8
       - rhel-9
 
   - job: copr_build
@@ -43,5 +42,4 @@ jobs:
     targets:
       - centos-stream-9
       - fedora-all
-      - rhel-8
       - rhel-9


### PR DESCRIPTION
* libygg requires ygddrasil >= 0.3.2, which is not available on RHEL8, and we do not have a plan to backport yggdrasil there
* The CentOS Stream 8 is EOL and it does not make sense to test libygg on this distribution
